### PR TITLE
BugFix: Proceed with next Word 9 and telegram printing

### DIFF
--- a/ss36/longnum.cpp
+++ b/ss36/longnum.cpp
@@ -346,7 +346,7 @@ void longnum::print_bin(int v)
 
     return_if_silent(v);
 
-    for (j = (order - 1) / BITS_IN_WORD; j >= 0; j--)
+    for (j = (order / BITS_IN_WORD)-1; j >= 0; j--)
     {
         printf("#%02d=", j);
         for (int i = BITS_IN_WORD - 1; i >= 0; i--)

--- a/ss36/telegram.cpp
+++ b/ss36/telegram.cpp
@@ -610,10 +610,9 @@ void telegram::shape(void)
         if ((err == ERR_OFF_SYNCH_PARSING) || (err == ERR_APERIODICITY))
             if (err_location >= OFFSET_SHAPED_DATA)
             // error sequence is located completely in the shaped user data, it is therefore pointless to update the ESB
-            // solution: set word9 and word10 so that the next word10 is selected in the next run
+            // solution: set ESB to 111, so the next word 9 and if necessary word10 are selected in the next run
             {
                 contents.write_at_location(N_CHECKBITS, &esb_mask, 3);  // set the lower three bits of the ESB to 111 
-                word9 = N_TRANS_WORDS;
             }
 
     } while (err);


### PR DESCRIPTION
Hi,

if error sequence is located completely in the shaped user data, it is pointless to update the ESB. In the original code it would proceed with the next word 10, but it is possible that a correct telegram is found by just proceeding to next word 9. The solution is to set ESB to 111, so the next word 9 and if necessary word10 are selected in the next run.

And in the printing of telegrams I got 11 padding zeros. I've changed the printing function, so it is printed correctly.